### PR TITLE
Add audio transcription and translation app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Variaveis de ambiente para o projeto de audio
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=audio_db
+DB_USER=usuario
+DB_PASSWORD=senha
+HUGGINGFACE_TOKEN=seu_token

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Trabalhando_com_audio_IA
+# Trabalhando com Audio IA
+
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio e traduzir o texto para diferentes idiomas. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+
+## Requisitos
+- Python 3.10+
+- PostgresSQL
+
+## Configuração
+1. Copie o arquivo `.env.example` para `.env` e ajuste as variáveis de ambiente.
+2. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Crie a tabela no banco de dados executando o script `schema.sql`.
+
+## Uso
+Execute `python main.py` e navegue pelo menu para transcrever ou traduzir áudio ou texto.

--- a/db.py
+++ b/db.py
@@ -1,0 +1,37 @@
+import os
+import psycopg2
+from psycopg2.extras import RealDictCursor
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_CONFIG = {
+    'host': os.getenv('DB_HOST'),
+    'port': os.getenv('DB_PORT'),
+    'dbname': os.getenv('DB_NAME'),
+    'user': os.getenv('DB_USER'),
+    'password': os.getenv('DB_PASSWORD'),
+}
+
+
+def get_conn():
+    return psycopg2.connect(**DB_CONFIG)
+
+
+def init_db():
+    with get_conn() as conn, conn.cursor() as cur:
+        with open('schema.sql', 'r', encoding='utf-8') as f:
+            cur.execute(f.read())
+        conn.commit()
+
+
+def save_record(user_name: str, subject: str, audio_path: str, original_text: str, translated_text: str):
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO audio_records (user_name, subject, audio_path, original_text, translated_text)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (user_name, subject, audio_path, original_text, translated_text)
+        )
+        conn.commit()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,72 @@
+import os
+from rich.console import Console
+from rich.prompt import Prompt, IntPrompt
+from dotenv import load_dotenv
+
+from speech import transcribe_audio
+from translator import translate_text, LANG_CODE
+from db import init_db, save_record
+
+load_dotenv()
+console = Console()
+
+LANG_OPTIONS = list(LANG_CODE.keys())
+
+
+def choose_language(message: str) -> str:
+    console.print(message)
+    for idx, lang in enumerate(LANG_OPTIONS, 1):
+        console.print(f"{idx}. {lang}")
+    choice = IntPrompt.ask("Escolha", choices=[str(i) for i in range(1, len(LANG_OPTIONS)+1)])
+    return LANG_OPTIONS[int(choice)-1]
+
+
+def transcribe_menu():
+    audio_path = Prompt.ask("Caminho do arquivo de áudio")
+    src_lang = choose_language("Idioma de origem:")
+    tgt_lang = choose_language("Idioma de destino:")
+
+    console.print("[bold]Transcrevendo...[/bold]")
+    original_text = transcribe_audio(audio_path, LANG_CODE[src_lang])
+    console.print("\n[bold]Texto extraído:[/bold]")
+    console.print(original_text)
+
+    console.print("\n[bold]Traduzindo...[/bold]")
+    translated_text = translate_text(original_text, src_lang, tgt_lang)
+    console.print("\n[bold]Texto traduzido:[/bold]")
+    console.print(translated_text)
+
+    if Prompt.ask("Deseja salvar no banco de dados? (s/n)", choices=["s", "n"], default="n") == "s":
+        user_name = Prompt.ask("Nome do usuário")
+        subject = Prompt.ask("Assunto")
+        save_record(user_name, subject, audio_path, original_text, translated_text)
+        console.print("Registro salvo com sucesso.")
+
+
+def translate_menu():
+    text = Prompt.ask("Texto para traduzir")
+    src_lang = choose_language("Idioma de origem:")
+    tgt_lang = choose_language("Idioma de destino:")
+    result = translate_text(text, src_lang, tgt_lang)
+    console.print("\n[bold]Texto traduzido:[/bold]")
+    console.print(result)
+
+
+def main():
+    init_db()
+    while True:
+        console.print("\n[bold]Menu[/bold]")
+        console.print("1. Transcrever áudio")
+        console.print("2. Traduzir texto")
+        console.print("3. Sair")
+        option = IntPrompt.ask("Escolha", choices=["1", "2", "3"])
+        if option == 1:
+            transcribe_menu()
+        elif option == 2:
+            translate_menu()
+        else:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+transformers
+torch
+python-dotenv
+psycopg2-binary
+rich

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS audio_records (
+    id SERIAL PRIMARY KEY,
+    user_name TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    audio_path TEXT NOT NULL,
+    original_text TEXT,
+    translated_text TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/speech.py
+++ b/speech.py
@@ -1,0 +1,14 @@
+import os
+from transformers import pipeline
+from translator import LANG_CODE
+
+
+def transcribe_audio(audio_path: str, language_name: str) -> str:
+    lang_code = LANG_CODE.get(language_name, 'en')
+    asr = pipeline(
+        "automatic-speech-recognition",
+        model="openai/whisper-large-v3-turbo",
+        token=os.getenv("HUGGINGFACE_TOKEN"),
+    )
+    result = asr(audio_path, generate_kwargs={"language": lang_code})
+    return result["text"].strip()

--- a/translator.py
+++ b/translator.py
@@ -1,0 +1,17 @@
+from transformers import pipeline
+
+LANG_CODE = {
+    'Português': 'pt',
+    'English': 'en',
+    'Español': 'es',
+    'Français': 'fr',
+}
+
+
+def translate_text(text: str, src_lang: str, tgt_lang: str) -> str:
+    src_code = LANG_CODE[src_lang]
+    tgt_code = LANG_CODE[tgt_lang]
+    model_name = f"Helsinki-NLP/opus-mt-{src_code}-{tgt_code}"
+    translator = pipeline('translation', model=model_name)
+    result = translator(text, max_length=400)
+    return result[0]['translation_text']


### PR DESCRIPTION
## Summary
- add environment template and gitignore
- document project setup in README
- define database schema
- implement database helper
- implement speech transcription with `openai/whisper-large-v3-turbo`
- implement text translation helpers
- provide CLI with menu options
- list Python requirements

## Testing
- `python -m py_compile main.py speech.py translator.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_685acabb2164832a90a248c388a95187