### PR TITLE
fix transcription for long audio

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -13,5 +13,9 @@ def transcribe_audio(audio_path: str, language_name: str) -> str:
         model="openai/whisper-large-v3-turbo",
         token=os.getenv("HUGGINGFACE_TOKEN"),
     )
-    result = asr(audio_path, generate_kwargs={"language": lang_code})
+    result = asr(
+        audio_path,
+        generate_kwargs={"language": lang_code},
+        return_timestamps=True,
+    )
     return result["text"].strip()


### PR DESCRIPTION
## Summary
- handle Whisper long-form transcription by enabling timestamps

## Testing
- `python -m py_compile main.py speech.py translator.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_685aeba53dc0832a987d02f49501a350