### PR TITLE
Remove Helsinki model dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trabalhando com Audio IA
 
-Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio e traduzir o texto para diferentes idiomas. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto é realizada por meio do serviço do Google Translate via biblioteca `googletrans`. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
 
 ## Requisitos
 - Python 3.10+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch
 python-dotenv
 psycopg2-binary
 rich
+googletrans==4.0.0-rc1

--- a/translator.py
+++ b/translator.py
@@ -1,4 +1,4 @@
-from transformers import pipeline
+from googletrans import Translator
 
 LANG_CODE = {
     'Português': 'pt',
@@ -7,11 +7,9 @@ LANG_CODE = {
     'Français': 'fr',
 }
 
-
 def translate_text(text: str, src_lang: str, tgt_lang: str) -> str:
+    translator = Translator()
     src_code = LANG_CODE[src_lang]
     tgt_code = LANG_CODE[tgt_lang]
-    model_name = f"Helsinki-NLP/opus-mt-{src_code}-{tgt_code}"
-    translator = pipeline('translation', model=model_name)
-    result = translator(text, max_length=400)
-    return result[0]['translation_text']
+    result = translator.translate(text, src=src_code, dest=tgt_code)
+    return result.text


### PR DESCRIPTION
## Summary
- use `googletrans` to translate text instead of Helsinki model
- document that translations rely on Google Translate
- include `googletrans` in requirements

## Testing
- `python -m py_compile translator.py main.py speech.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_685aede5b9a8832aa2298b693e6e2b9d