### PR TITLE
Improve translation reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trabalhando com Audio IA
 
-Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto é realizada por meio do serviço do Google Translate via biblioteca `googletrans`. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto é realizada por meio do serviço do Google Translate via biblioteca `googletrans`. Para maior estabilidade, a biblioteca foi configurada para usar a API pública `translate.googleapis.com`. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
 
 ## Requisitos
 - Python 3.10+

--- a/db.py
+++ b/db.py
@@ -1,6 +1,5 @@
 import os
 import psycopg2
-from psycopg2.extras import RealDictCursor
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import os
 from rich.console import Console
 from rich.prompt import Prompt, IntPrompt
 from dotenv import load_dotenv

--- a/translator.py
+++ b/translator.py
@@ -8,8 +8,41 @@ LANG_CODE = {
 }
 
 def translate_text(text: str, src_lang: str, tgt_lang: str) -> str:
-    translator = Translator()
+    """Translate text between supported languages.
+
+    Parameters
+    ----------
+    text: str
+        The input text to translate.
+    src_lang: str
+        Human readable source language name.
+    tgt_lang: str
+        Human readable target language name.
+
+    Returns
+    -------
+    str
+        Translated text.
+
+    Raises
+    ------
+    RuntimeError
+        If the translation service fails to return a valid result.
+    """
+
+    # Using translate.googleapis.com directly avoids some parsing issues that
+    # occur when hitting the default endpoint via googletrans.
+    translator = Translator(service_urls=["translate.googleapis.com"])
+
     src_code = LANG_CODE[src_lang]
     tgt_code = LANG_CODE[tgt_lang]
-    result = translator.translate(text, src=src_code, dest=tgt_code)
+
+    try:
+        result = translator.translate(text, src=src_code, dest=tgt_code)
+    except Exception as exc:
+        raise RuntimeError(f"Falha ao traduzir o texto: {exc}") from exc
+
+    if result is None or result.text is None:
+        raise RuntimeError("Serviço de tradução retornou resultado vazio")
+
     return result.text


### PR DESCRIPTION
## Summary
- use `translate.googleapis.com` in `Translator`
- add error handling when translation fails
- mention new translation endpoint in README
- clean up unused imports

## Testing
- `pyright` *(fails: missing imports)*
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_685af29df32c832a938427b92280c653