### PR TITLE
Fix googletrans runtime error

### DIFF
--- a/translator.py
+++ b/translator.py
@@ -33,6 +33,11 @@ def translate_text(text: str, src_lang: str, tgt_lang: str) -> str:
     # Using translate.googleapis.com directly avoids some parsing issues that
     # occur when hitting the default endpoint via googletrans.
     translator = Translator(service_urls=["translate.googleapis.com"])
+    # googletrans 4.0.0-rc1 expects an attribute named ``raise_Exception`` in
+    # ``Translator._translate`` but only ``raise_exception`` is defined. Add the
+    # missing attribute for compatibility with this library version.
+    if not hasattr(translator, "raise_Exception"):
+        translator.raise_Exception = getattr(translator, "raise_exception", True)
 
     src_code = LANG_CODE[src_lang]
     tgt_code = LANG_CODE[tgt_lang]


### PR DESCRIPTION
## Summary
- workaround googletrans bug by adding missing `raise_Exception` attribute

## Testing
- `python -m py_compile translator.py main.py speech.py db.py`
- `python - <<'PY'
from translator import translate_text
try:
    print(translate_text('hello', 'English', 'Português'))
except Exception as e:
    print('error', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685af4498aac832abc0b54e55b2f3a44