### PR TITLE
Fix language mapping and use Whisper for translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trabalhando com Audio IA
 
-Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever e traduzir arquivos de áudio. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
 
 ## Requisitos
 - Python 3.10+

--- a/languages.py
+++ b/languages.py
@@ -1,15 +1,9 @@
+# Language codes expected by Whisper and the translation pipeline. The
+# values correspond to the full language names recognised by the model.
 LANG_CODE = {
-    'Português': 'por',
-    'English': 'eng',
-    'Español': 'spa',
-    'Français': 'fra',
+    'Português': 'portuguese',
+    'English': 'english',
+    'Español': 'spanish',
+    'Français': 'french',
 }
 
-# Mapping from 3-letter ISO-639-3 codes used by Whisper to the
-# language codes expected by the NLLB translation model.
-NLLB_CODE = {
-    'por': 'por_Latn',
-    'eng': 'eng_Latn',
-    'spa': 'spa_Latn',
-    'fra': 'fra_Latn',
-}

--- a/translation.py
+++ b/translation.py
@@ -2,29 +2,28 @@ import os
 from functools import lru_cache
 from transformers import pipeline
 
-from languages import NLLB_CODE
 
 
 @lru_cache(maxsize=1)
 def _get_translator():
-    """Return a lazily loaded translation pipeline."""
+    """Return a lazily loaded translation pipeline using Whisper."""
     return pipeline(
         "translation",
-        model="facebook/nllb-200-distilled-600M",
+        model="openai/whisper-large-v3-turbo",
         token=os.getenv("HUGGINGFACE_TOKEN"),
     )
 
 
 def translate_text(text: str, src_code: str, tgt_code: str) -> str:
-    """Translate ``text`` from ``src_code`` to ``tgt_code`` using NLLB."""
+    """Translate ``text`` from ``src_code`` to ``tgt_code`` using Whisper."""
     if src_code == tgt_code:
         return text
 
     translator = _get_translator()
     result = translator(
         text,
-        src_lang=NLLB_CODE[src_code],
-        tgt_lang=NLLB_CODE[tgt_code],
+        src_lang=src_code,
+        tgt_lang=tgt_code,
         max_length=400,
     )
     return result[0]["translation_text"]


### PR DESCRIPTION
## Summary
- fix README to mention translation via Whisper
- adjust language codes to use Whisper's expected names
- swap translation model to `openai/whisper-large-v3-turbo`

## Testing
- `python -m py_compile main.py languages.py translation.py speech.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_685afddaa160832a811385f938850e3f