### PR TITLE
Add OpenAI translation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ DB_NAME=audio_db
 DB_USER=usuario
 DB_PASSWORD=senha
 HUGGINGFACE_TOKEN=seu_token
+OPENAI_API_KEY=sua_chave

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trabalhando com Audio IA
 
-Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio e do `facebook/nllb-200-distilled-600M` para tradução de texto. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio e da API `gpt-3.5-turbo` da OpenAI para traduzir texto. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
 
 ## Requisitos
 - Python 3.10+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 psycopg2-binary
 rich
 sentencepiece
+openai

--- a/translation.py
+++ b/translation.py
@@ -1,49 +1,54 @@
 import os
 from functools import lru_cache
-from transformers import pipeline
+import openai
 
 
 
-LANG_TOKEN = {
-    "portuguese": "por_Latn",
-    "english": "eng_Latn",
-    "spanish": "spa_Latn",
-    "french": "fra_Latn",
+LANG_NAME = {
+    "portuguese": "Portuguese",
+    "english": "English",
+    "spanish": "Spanish",
+    "french": "French",
 }
 
 
 @lru_cache(maxsize=1)
-def _get_translator():
-    """Return a lazily loaded translation pipeline using NLLB."""
-    return pipeline(
-        "translation",
-        model="facebook/nllb-200-distilled-600M",
-        token=os.getenv("HUGGINGFACE_TOKEN"),
-    )
+def _get_client():
+    """Return OpenAI API client with API key loaded from environment."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+    return openai
 
 
-def _chunk_text(text: str, size: int = 512) -> list[str]:
-    """Split ``text`` into smaller chunks of approximately ``size`` characters."""
+def _chunk_text(text: str, size: int = 1500) -> list[str]:
+    """Split ``text`` into smaller chunks for the API limit."""
     return [text[i : i + size] for i in range(0, len(text), size)]
 
 
 def translate_text(text: str, src_code: str, tgt_code: str) -> str:
-    """Translate ``text`` from ``src_code`` to ``tgt_code`` using NLLB."""
+    """Translate ``text`` from ``src_code`` to ``tgt_code`` using OpenAI."""
     if src_code == tgt_code:
         return text
 
-    translator = _get_translator()
-    src_lang = LANG_TOKEN[src_code]
-    tgt_lang = LANG_TOKEN[tgt_code]
+    client = _get_client()
+    src_lang = LANG_NAME[src_code]
+    tgt_lang = LANG_NAME[tgt_code]
 
     translations = []
     for chunk in _chunk_text(text):
-        result = translator(
-            chunk,
-            src_lang=src_lang,
-            tgt_lang=tgt_lang,
-            max_length=512,
+        response = client.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": f"Translate from {src_lang} to {tgt_lang}.",
+                },
+                {"role": "user", "content": chunk},
+            ],
+            temperature=0,
         )
-        translations.append(result[0]["translation_text"])
+        translations.append(response.choices[0].message.content.strip())
 
     return " ".join(translations)


### PR DESCRIPTION
## Summary
- switch translation from Facebook NLLB to OpenAI ChatGPT
- document new translation approach
- add OPENAI_API_KEY variable example
- include openai package in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b048ad5fc832a9ffea1c7d8d18b14