### PR TITLE
Fix whisper language arg

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -17,7 +17,7 @@ def transcribe_audio(audio_path: str, language_code: str) -> str:
     )
     result = asr(
         audio_path,
-        generate_kwargs={"language": language_code},
+        language=language_code,
         return_timestamps=True,
     )
     return result["text"].strip()


### PR DESCRIPTION
## Summary
- use `language` param directly for whisper pipeline to avoid `forced_decoder_ids` warning

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b0b2447a4832ab6d94c802ee086b2