### PR TITLE
Add translation model selection menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trabalhando com Audio IA
 
-Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio e do modelo `facebook/nllb-200-distilled-600M` para traduzir texto localmente. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto pode ser realizada tanto com o `facebook/nllb-200-distilled-600M` quanto com o próprio `openai/whisper-large-v3-turbo`, escolhidos por meio de um menu interativo. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
 
 ## Requisitos
 - Python 3.10+

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from rich.prompt import Prompt, IntPrompt
 from dotenv import load_dotenv
 
 from speech import transcribe_audio
-from translation import translate_text
+from translation import translate_text, set_translation_model, MODEL_OPTIONS
 from languages import LANG_CODE
 from db import init_db, save_record
 
@@ -25,6 +25,12 @@ def transcribe_menu():
     audio_path = Prompt.ask("Caminho do arquivo de áudio")
     src_lang = choose_language("Idioma de origem:")
     tgt_lang = choose_language("Traduzir para:")
+
+    console.print("\nEscolha o modelo de tradução:")
+    for key, name in MODEL_OPTIONS.items():
+        console.print(f"{key}. {name}")
+    model_choice = IntPrompt.ask("Opção", choices=list(MODEL_OPTIONS.keys()))
+    set_translation_model(str(model_choice))
 
     console.print("[bold]Transcrevendo...[/bold]")
     original_text = transcribe_audio(audio_path, LANG_CODE[src_lang])

--- a/translation.py
+++ b/translation.py
@@ -9,7 +9,29 @@ NLLB_CODES = {
     "french": "fra_Latn",
 }
 
-MODEL_NAME = "facebook/nllb-200-distilled-600M"
+# Available translation models. The ``MODEL_NAME`` value can be switched at
+# runtime using :func:`set_translation_model`.
+MODEL_OPTIONS = {
+    "1": "facebook/nllb-200-distilled-600M",
+    "2": "openai/whisper-large-v3-turbo",
+}
+
+MODEL_NAME = MODEL_OPTIONS["1"]
+
+
+def set_translation_model(option: str) -> None:
+    """Set the translation model to one of ``MODEL_OPTIONS``.
+
+    Parameters
+    ----------
+    option:
+        The key corresponding to the desired model in ``MODEL_OPTIONS``.
+    """
+    global MODEL_NAME
+    if option not in MODEL_OPTIONS:
+        raise ValueError("Opção de modelo inválida")
+    MODEL_NAME = MODEL_OPTIONS[option]
+    _load_model.cache_clear()
 
 
 @lru_cache(maxsize=1)
@@ -26,7 +48,7 @@ def _chunk_text(text: str, size: int = 512) -> list[str]:
 
 
 def translate_text(text: str, src_code: str, tgt_code: str) -> str:
-    """Translate ``text`` from ``src_code`` to ``tgt_code`` using NLLB."""
+    """Translate ``text`` from ``src_code`` to ``tgt_code`` using the selected model."""
     if src_code == tgt_code:
         return text
 


### PR DESCRIPTION
## Summary
- allow switching translation models via `set_translation_model` in `translation.py`
- prompt for the translation model choice in `transcribe_menu`
- document the new feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- *(fails: ModuleNotFoundError: No module named 'transformers' when running a runtime check)*

------
https://chatgpt.com/codex/tasks/task_e_685b0df69528832ab6d4487c15eaddce