### PR TITLE
Enable translation with OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ DB_NAME=audio_db
 DB_USER=usuario
 DB_PASSWORD=senha
 HUGGINGFACE_TOKEN=seu_token
+OPENAI_API_KEY=sua_chave

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trabalhando com Audio IA
 
-Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto pode ser realizada tanto com o `facebook/nllb-200-distilled-600M` quanto com o próprio `openai/whisper-large-v3-turbo`, escolhidos por meio de um menu interativo. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto pode ser realizada tanto com o modelo `facebook/nllb-200-distilled-600M` quanto com a API `gpt-3.5-turbo` da OpenAI, escolhidos por meio de um menu interativo. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
 
 ## Requisitos
 - Python 3.10+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 psycopg2-binary
 rich
 sentencepiece
+openai


### PR DESCRIPTION
## Summary
- allow choosing gpt-3.5-turbo for translation
- document the new option in README
- expose `OPENAI_API_KEY` in `.env.example`
- update requirements with openai dependency

## Testing
- `python -m py_compile *.py`
- `python -m pip install openai`
- `python -m pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685b1164d344832a912d67288c74311f