### PR TITLE
Remove translation model menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trabalhando com Audio IA
 
-Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto pode ser realizada tanto com o `facebook/nllb-200-distilled-600M` quanto com o próprio `openai/whisper-large-v3-turbo`, escolhidos por meio de um menu interativo. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
+Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da HuggingFace para transcrever arquivos de áudio. A tradução do texto é feita com o modelo `facebook/nllb-200-distilled-600M`. Os resultados podem ser opcionalmente armazenados em um banco de dados PostgreSQL.
 
 ## Requisitos
 - Python 3.10+

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from rich.prompt import Prompt, IntPrompt
 from dotenv import load_dotenv
 
 from speech import transcribe_audio
-from translation import translate_text, set_translation_model, MODEL_OPTIONS
+from translation import translate_text
 from languages import LANG_CODE
 from db import init_db, save_record
 
@@ -26,11 +26,6 @@ def transcribe_menu():
     src_lang = choose_language("Idioma de origem:")
     tgt_lang = choose_language("Traduzir para:")
 
-    console.print("\nEscolha o modelo de tradução:")
-    for key, name in MODEL_OPTIONS.items():
-        console.print(f"{key}. {name}")
-    model_choice = IntPrompt.ask("Opção", choices=list(MODEL_OPTIONS.keys()))
-    set_translation_model(str(model_choice))
 
     console.print("[bold]Transcrevendo...[/bold]")
     original_text = transcribe_audio(audio_path, LANG_CODE[src_lang])

--- a/translation.py
+++ b/translation.py
@@ -9,29 +9,8 @@ NLLB_CODES = {
     "french": "fra_Latn",
 }
 
-# Available translation models. The ``MODEL_NAME`` value can be switched at
-# runtime using :func:`set_translation_model`.
-MODEL_OPTIONS = {
-    "1": "facebook/nllb-200-distilled-600M",
-    "2": "facebook/m2m100_418M",
-}
-
-MODEL_NAME = MODEL_OPTIONS["1"]
-
-
-def set_translation_model(option: str) -> None:
-    """Set the translation model to one of ``MODEL_OPTIONS``.
-
-    Parameters
-    ----------
-    option:
-        The key corresponding to the desired model in ``MODEL_OPTIONS``.
-    """
-    global MODEL_NAME
-    if option not in MODEL_OPTIONS:
-        raise ValueError("Opção de modelo inválida")
-    MODEL_NAME = MODEL_OPTIONS[option]
-    _load_model.cache_clear()
+# Translation model used by default.
+MODEL_NAME = "facebook/nllb-200-distilled-600M"
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- default translation uses `facebook/nllb-200-distilled-600M`
- drop menu option to select translation model
- update docs for the default translator

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c00da09cc832ab4cf0571d6f4e9cf