### PR TITLE
Add basic Flask web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .env
+uploads/

--- a/README.md
+++ b/README.md
@@ -20,4 +20,15 @@ Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da Huggin
 3. Crie a tabela no banco de dados executando o script `schema.sql`.
 
 ## Uso
-Execute `python main.py` e navegue pelo menu para transcrever arquivos de áudio.
+Para utilizar no terminal, execute `python main.py` e navegue pelo menu para
+transcrever arquivos de áudio.
+
+Também é possível acessar as mesmas funcionalidades via navegador iniciando o
+servidor web:
+
+```bash
+python web.py
+```
+
+Depois, abra `http://localhost:5000` para enviar o áudio pela interface
+gráfica.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 psycopg2-binary
 rich
 sentencepiece
+flask

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Transcrever Áudio</title>
+</head>
+<body>
+    <h1>Transcrever e Traduzir Áudio</h1>
+    <form action="/transcrever" method="post" enctype="multipart/form-data">
+        <label for="audio">Arquivo de áudio:</label>
+        <input type="file" name="audio" id="audio" required><br><br>
+
+        <label for="src_lang">Idioma de origem:</label>
+        <select name="src_lang" id="src_lang">
+            {% for lang in langs %}
+            <option value="{{ lang }}">{{ lang }}</option>
+            {% endfor %}
+        </select><br><br>
+
+        <label for="tgt_lang">Traduzir para:</label>
+        <select name="tgt_lang" id="tgt_lang">
+            {% for lang in langs %}
+            <option value="{{ lang }}">{{ lang }}</option>
+            {% endfor %}
+        </select><br><br>
+
+        <label for="user_name">Nome do usuário:</label>
+        <input type="text" name="user_name" id="user_name"><br><br>
+
+        <label for="subject">Assunto:</label>
+        <input type="text" name="subject" id="subject"><br><br>
+
+        <label for="save">Salvar no banco de dados:</label>
+        <input type="checkbox" name="save" id="save" value="1"><br><br>
+
+        <button type="submit">Processar</button>
+    </form>
+    {% if original_text %}
+    <h2>Texto Extraído</h2>
+    <p>{{ original_text }}</p>
+    <h2>Texto Traduzido</h2>
+    <p>{{ translated_text }}</p>
+    {% endif %}
+</body>
+</html>

--- a/web.py
+++ b/web.py
@@ -1,0 +1,42 @@
+from flask import Flask, render_template, request
+from werkzeug.utils import secure_filename
+import os
+from speech import transcribe_audio
+from translation import translate_text
+from languages import LANG_CODE
+from db import init_db, save_record
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = 'uploads'
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+
+LANG_OPTIONS = list(LANG_CODE.keys())
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('index.html', langs=LANG_OPTIONS, original_text=None, translated_text=None)
+
+@app.route('/transcrever', methods=['POST'])
+def transcrever():
+    file = request.files['audio']
+    src_lang = request.form['src_lang']
+    tgt_lang = request.form['tgt_lang']
+    user_name = request.form.get('user_name')
+    subject = request.form.get('subject')
+    save_db = request.form.get('save') == '1'
+
+    filename = secure_filename(file.filename)
+    file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+    file.save(file_path)
+
+    original_text = transcribe_audio(file_path, LANG_CODE[src_lang])
+    translated_text = translate_text(original_text, LANG_CODE[src_lang], LANG_CODE[tgt_lang])
+
+    if save_db and user_name and subject:
+        save_record(user_name, subject, file_path, original_text, translated_text)
+
+    return render_template('index.html', langs=LANG_OPTIONS, original_text=original_text, translated_text=translated_text)
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- set up a small web server using Flask
- display a form to upload audio and select languages
- process transcription/translation and optionally save results
- document how to use the web interface

## Testing
- `python -m py_compile db.py languages.py main.py speech.py translation.py web.py`
- `python web.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c06990a54832aa62ae18e707c1bb6