### PR TITLE
Add session selection step

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -37,12 +37,12 @@
 
             <div class="mb-3">
                 <label for="user_name" class="form-label">Nome do usuário:</label>
-                <input type="text" name="user_name" id="user_name" class="form-control">
+                <input type="text" name="user_name" id="user_name" class="form-control" value="{{ user_name }}" readonly>
             </div>
 
             <div class="mb-3">
                 <label for="session_name" class="form-label">Nome da sessão:</label>
-                <input type="text" name="session_name" id="session_name" class="form-control">
+                <input type="text" name="session_name" id="session_name" class="form-control" value="{{ session_name }}" readonly>
             </div>
 
             <div class="mb-3">

--- a/templates/sessions.html
+++ b/templates/sessions.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Selecionar Sessão</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h1 class="mb-4 text-center">Escolha a Sessão</h1>
+        <form method="post" class="bg-white p-4 rounded shadow-sm mb-4">
+            <div class="mb-3">
+                <label for="user_name" class="form-label">Nome do usuário:</label>
+                <input type="text" name="user_name" id="user_name" class="form-control" value="{{ user_name or '' }}" required>
+            </div>
+            <button type="submit" class="btn btn-primary">Buscar Sessões</button>
+        </form>
+        {% if sessions is not none %}
+        <div class="bg-white p-4 rounded shadow-sm">
+            <h2 class="mb-3">Sessões de {{ user_name }}</h2>
+            <ul class="list-group mb-3">
+                {% for s in sessions %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    {{ s.session_name }}
+                    <span class="badge bg-secondary">{{ s.record_count }} registros</span>
+                    <a class="btn btn-sm btn-outline-primary" href="{{ url_for('index', user_name=user_name, session_name=s.session_name) }}">Abrir</a>
+                </li>
+                {% endfor %}
+            </ul>
+            <form action="{{ url_for('index') }}" method="get" class="mt-3">
+                <input type="hidden" name="user_name" value="{{ user_name }}">
+                <div class="input-group">
+                    <input type="text" name="session_name" class="form-control" placeholder="Nova sessão" required>
+                    <button class="btn btn-success" type="submit">Criar/Abrir</button>
+                </div>
+            </form>
+        </div>
+        {% endif %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a page to choose the session before processing audio
- pre-fill and lock user and session fields on the main panel
- list previous sessions for each user

## Testing
- `python -m py_compile web.py db.py languages.py main.py speech.py translation.py`
- `flake8` *(fails: E501 line too long, E302, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_685c0e78a8ec832aa2b0a10c17a19226