### PR TITLE
Exibir histórico de áudios por sessão

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ python web.py
 
 Depois, abra `http://localhost:5000` para enviar o áudio pela interface
 gráfica.
+
+Ao abrir uma sessão existente, serão listados todos os áudios já processados,
+incluindo o texto extraído e o texto traduzido. A página também informa os
+modelos utilizados: `openai/whisper-large-v3-turbo` para transcrição e
+`facebook/nllb-200-distilled-600M` para tradução.

--- a/db.py
+++ b/db.py
@@ -89,3 +89,30 @@ def list_sessions(user_name: str) -> list[dict]:
         return [
             {"session_name": r[0], "record_count": r[1]} for r in rows
         ]
+
+
+def list_records(user_name: str, session_name: str) -> list[dict]:
+    """Return all audio records for ``session_name`` of ``user_name``."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT ar.subject, ar.audio_path, ar.original_text, ar.translated_text, ar.created_at
+            FROM audio_records ar
+            JOIN sessions s ON ar.session_id = s.id
+            JOIN users u ON s.user_id = u.id
+            WHERE u.name = %s AND s.session_name = %s
+            ORDER BY ar.created_at DESC
+            """,
+            (user_name, session_name),
+        )
+        rows = cur.fetchall()
+        return [
+            {
+                "subject": r[0],
+                "audio_path": r[1],
+                "original_text": r[2],
+                "translated_text": r[3],
+                "created_at": r[4],
+            }
+            for r in rows
+        ]

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,6 +71,39 @@
                 {% endfor %}
             {% endif %}
         </div>
+
+        {% if records %}
+        <div class="mt-5">
+            <h2 class="h4 mb-3">Áudios processados</h2>
+            <div class="table-responsive">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>Assunto</th>
+                            <th>Áudio</th>
+                            <th>Texto Extraído</th>
+                            <th>Texto Traduzido</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for rec in records %}
+                        <tr>
+                            <td>{{ rec.subject }}</td>
+                            <td><a href="{{ rec.audio_path }}" target="_blank">Arquivo</a></td>
+                            <td>{{ rec.original_text }}</td>
+                            <td>{{ rec.translated_text }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="alert alert-info mt-4" role="alert">
+            Este aplicativo utiliza o modelo <strong>openai/whisper-large-v3-turbo</strong>
+            para transcrição e o <strong>facebook/nllb-200-distilled-600M</strong> para tradução.
+        </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}"></script>

--- a/web.py
+++ b/web.py
@@ -4,7 +4,7 @@ import os
 from speech import transcribe_audio
 from translation import translate_text
 from languages import LANG_CODE
-from db import init_db, save_record, list_sessions
+from db import init_db, save_record, list_sessions, list_records
 
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = 'uploads'
@@ -32,8 +32,15 @@ def index():
     session_name = request.args.get('session_name')
     if not user_name or not session_name:
         return redirect(url_for('sessions_view'))
-    return render_template('index.html', langs=LANG_OPTIONS, results=None,
-                           user_name=user_name, session_name=session_name)
+    records = list_records(user_name, session_name)
+    return render_template(
+        'index.html',
+        langs=LANG_OPTIONS,
+        results=None,
+        records=records,
+        user_name=user_name,
+        session_name=session_name,
+    )
 
 @app.route('/transcrever', methods=['POST'])
 def transcrever():
@@ -59,8 +66,15 @@ def transcrever():
 
         results.append({'filename': filename, 'original_text': original_text, 'translated_text': translated_text})
 
-    return render_template('index.html', langs=LANG_OPTIONS, results=results,
-                           user_name=user_name, session_name=session_name)
+    records = list_records(user_name, session_name)
+    return render_template(
+        'index.html',
+        langs=LANG_OPTIONS,
+        results=results,
+        records=records,
+        user_name=user_name,
+        session_name=session_name,
+    )
 
 @app.route('/api/transcribe', methods=['POST'])
 def api_transcribe():


### PR DESCRIPTION
## Resumo
- adicionar função `list_records` no `db.py`
- exibir registros existentes na rota `/panel`
- atualizar envio para retornar também os registros
- mostrar na interface os áudios processados em tabela
- mencionar modelos utilizados no README e na interface

## Testes
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c10388b68832aafcd1b65ef81a0de