### PR TITLE
Improve user/session relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Este projeto demonstra o uso do modelo `openai/whisper-large-v3-turbo` da Huggin
 
 3. Crie a tabela no banco de dados executando o script `schema.sql`.
 
+## Estrutura do Banco de Dados
+O banco utiliza três tabelas principais:
+
+- `users` guarda os usuários cadastrados.
+- `sessions` registra as sessões associadas a um usuário. O par
+  `(user_id, session_name)` é único, permitindo que um mesmo usuário tenha
+  várias sessões.
+- `audio_records` armazena os áudios processados e referencia a sessão em que
+  foram criados.
+
+Assim, um usuário pode ter nenhuma ou várias sessões, enquanto cada sessão é
+sempre vinculada a apenas um usuário.
+
 ## Uso
 Para utilizar no terminal, execute `python main.py` e navegue pelo menu para
 transcrever arquivos de áudio.

--- a/db.py
+++ b/db.py
@@ -56,6 +56,17 @@ def get_or_create_session(user_id: int, session_name: str) -> int:
         return session_id
 
 
+def ensure_user(user_name: str) -> int:
+    """Return ``user_id`` creating the user if needed."""
+    return get_or_create_user(user_name)
+
+
+def ensure_session(user_name: str, session_name: str) -> int:
+    """Ensure session exists for ``user_name`` and return its id."""
+    user_id = ensure_user(user_name)
+    return get_or_create_session(user_id, session_name)
+
+
 def save_record(user_name: str, session_name: str, subject: str, audio_path: str, original_text: str, translated_text: str):
     user_id = get_or_create_user(user_name)
     session_id = get_or_create_session(user_id, session_name)

--- a/web.py
+++ b/web.py
@@ -4,7 +4,14 @@ import os
 from speech import transcribe_audio
 from translation import translate_text
 from languages import LANG_CODE
-from db import init_db, save_record, list_sessions, list_records
+from db import (
+    init_db,
+    save_record,
+    list_sessions,
+    list_records,
+    ensure_session,
+    ensure_user,
+)
 
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = 'uploads'
@@ -19,9 +26,11 @@ def sessions_view():
     sessions = None
     if request.method == 'POST':
         user_name = request.form['user_name']
+        ensure_user(user_name)
         sessions = list_sessions(user_name)
     elif request.args.get('user_name'):
         user_name = request.args['user_name']
+        ensure_user(user_name)
         sessions = list_sessions(user_name)
     return render_template('sessions.html', user_name=user_name, sessions=sessions)
 
@@ -32,6 +41,7 @@ def index():
     session_name = request.args.get('session_name')
     if not user_name or not session_name:
         return redirect(url_for('sessions_view'))
+    ensure_session(user_name, session_name)
     records = list_records(user_name, session_name)
     return render_template(
         'index.html',


### PR DESCRIPTION
## Summary
- ensure user and session tables are created when navigating via the web UI
- document DB tables and relationship between users, sessions and audio records

## Testing
- `python -m py_compile db.py web.py main.py languages.py speech.py translation.py`

------
https://chatgpt.com/codex/tasks/task_e_685c121f79d4832aa0e141653e92de86