### PR TITLE
Improve UX with progress bar and collapsible history

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -2,58 +2,63 @@
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('audio-form');
     const progress = document.getElementById('progress');
+    const progressBar = document.getElementById('progress-bar');
+    const progressLabel = document.getElementById('progress-label');
     const resultsBox = document.getElementById('results');
 
     if (!form) return;
 
     form.addEventListener('submit', async function (e) {
         e.preventDefault();
-        progress.innerHTML = '';
         resultsBox.innerHTML = '';
+        progressBar.style.width = '0%';
+        progressLabel.textContent = '';
 
         const files = document.getElementById('audio').files;
         const commonData = new FormData(form);
 
         try {
-        for (const file of files) {
-            progress.innerHTML = '<div class="d-flex align-items-center"><div class="spinner-border me-2" role="status"></div><strong>Processando ' + file.name + '...</strong></div>';
+            for (let i = 0; i < files.length; i++) {
+                const file = files[i];
+                progressLabel.innerHTML = '<div class="d-flex align-items-center"><div class="spinner-border me-2" role="status"></div><strong>Processando ' + file.name + '...</strong></div>';
+                progressBar.style.width = ((i / files.length) * 100) + '%';
 
-            const fd = new FormData();
-            fd.append('audio', file);
-            fd.append('src_lang', commonData.get('src_lang'));
+                const fd = new FormData();
+                fd.append('audio', file);
+                fd.append('src_lang', commonData.get('src_lang'));
 
-            const resp = await fetch('/api/transcribe', { method: 'POST', body: fd });
-            if (!resp.ok) { progress.innerHTML = 'Erro na transcrição'; break; }
-            const data = await resp.json();
+                const resp = await fetch('/api/transcribe', { method: 'POST', body: fd });
+                if (!resp.ok) { progressLabel.textContent = 'Erro na transcrição'; break; }
+                const data = await resp.json();
 
-            progress.innerHTML = '<div class="d-flex align-items-center"><div class="spinner-border me-2" role="status"></div><strong>Traduzindo...</strong></div>';
+                progressLabel.innerHTML = '<div class="d-flex align-items-center"><div class="spinner-border me-2" role="status"></div><strong>Traduzindo...</strong></div>';
 
-            const td = new FormData();
-            td.append('text', data.original_text);
-            td.append('src_lang', commonData.get('src_lang'));
-            td.append('tgt_lang', commonData.get('tgt_lang'));
-            td.append('user_name', commonData.get('user_name'));
-            td.append('session_name', commonData.get('session_name'));
-            td.append('subject', commonData.get('subject'));
-            td.append('save', commonData.get('save'));
-            td.append('file_path', data.file_path);
+                const td = new FormData();
+                td.append('text', data.original_text);
+                td.append('src_lang', commonData.get('src_lang'));
+                td.append('tgt_lang', commonData.get('tgt_lang'));
+                td.append('user_name', commonData.get('user_name'));
+                td.append('session_name', commonData.get('session_name'));
+                td.append('subject', commonData.get('subject'));
+                td.append('save', commonData.get('save'));
+                td.append('file_path', data.file_path);
 
-            const resp2 = await fetch('/api/translate', { method: 'POST', body: td });
-            if (!resp2.ok) { progress.innerHTML = 'Erro na tradução'; break; }
-            const data2 = await resp2.json();
+                const resp2 = await fetch('/api/translate', { method: 'POST', body: td });
+                if (!resp2.ok) { progressLabel.textContent = 'Erro na tradução'; break; }
+                const data2 = await resp2.json();
 
-            const item = document.createElement('div');
-            item.className = 'mb-4';
-            item.innerHTML = '<h4>' + file.name + '</h4>' +
-                '<strong>Texto Extraído:</strong><p>' + data.original_text + '</p>' +
-                '<strong>Texto Traduzido:</strong><p>' + data2.translated_text + '</p>';
-            resultsBox.appendChild(item);
+                const item = document.createElement('div');
+                item.className = 'mb-4';
+                item.innerHTML = '<h4>' + file.name + '</h4>' +
+                    '<strong>Texto Extraído:</strong><p>' + data.original_text + '</p>' +
+                    '<strong>Texto Traduzido:</strong><p>' + data2.translated_text + '</p>';
+                resultsBox.appendChild(item);
+                progressBar.style.width = (((i + 1) / files.length) * 100) + '%';
+            }
+            progressLabel.innerHTML = '<span class="text-success">Concluído.</span>';
+        } catch (err) {
+            progressLabel.innerHTML = '<span class="text-danger">Ocorreu um erro no processamento.</span>';
         }
-        progress.innerHTML = '';
-        }
-    } catch (err) {
-        progress.innerHTML = '<span class="text-danger">Ocorreu um erro no processamento.</span>';
-    }
     });
 });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,7 +57,12 @@
 
             <button type="submit" class="btn btn-primary w-100">Processar</button>
         </form>
-        <div id="progress" class="mt-4"></div>
+        <div id="progress" class="mt-4">
+            <div class="progress">
+                <div id="progress-bar" class="progress-bar" role="progressbar" style="width: 0%"></div>
+            </div>
+            <div id="progress-label" class="mt-2"></div>
+        </div>
         <div id="results" class="mt-5 result-box">
             {% if results %}
                 {% for r in results %}
@@ -74,9 +79,13 @@
 
         {% if records %}
         <div class="mt-5">
-            <h2 class="h4 mb-3">Áudios processados</h2>
-            <div class="table-responsive">
-                <table class="table table-striped">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="h4 mb-0">Áudios processados</h2>
+                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#records-collapse">Mostrar/Esconder</button>
+            </div>
+            <div class="collapse show" id="records-collapse">
+                <div class="table-responsive">
+                    <table class="table table-striped">
                     <thead>
                         <tr>
                             <th>Assunto</th>


### PR DESCRIPTION
## Summary
- show actual progress bar during audio processing
- allow hiding of processed audio table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c15bbd67c832a9785284090417f41