### PR TITLE
Add authentication system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Os resultados podem opcionalmente ser salvos em um banco PostgreSQL, permitindo 
 - **Armazenamento opcional** dos resultados no banco de dados com registro de usuário, sessão e assunto.
 - **Interface de linha de comando** simples para processar arquivos locais.
 - **Aplicação web** em Flask com upload de múltiplos áudios, painel de sessões e visualização dos resultados.
+- **Autenticação de usuários** com senha e PIN para recuperação de acesso.
 
 ## Requisitos
 
@@ -52,13 +53,13 @@ Para utilizar pelo navegador, inicie o servidor Flask:
 python web.py
 ```
 
-Acesse `http://localhost:5000` e informe o nome do usuário para visualizar ou criar sessões. Dentro de cada sessão é possível fazer upload de um ou mais arquivos de áudio, definir os idiomas e opcionalmente salvar cada transcrição no banco de dados. O painel também lista todos os áudios já processados com seus textos originais e traduzidos.
+Acesse `http://localhost:5000` para fazer login ou criar uma conta. Após entrar, escolha ou crie uma sessão. Dentro de cada sessão é possível fazer upload de um ou mais arquivos de áudio, definir os idiomas e opcionalmente salvar cada transcrição no banco de dados. O painel também lista todos os áudios já processados com seus textos originais e traduzidos.
 
 ## Estrutura do Banco de Dados
 
 O banco utiliza três tabelas principais:
 
-- `users` – guarda os usuários cadastrados.
+- `users` – guarda os usuários cadastrados junto com o hash da senha e o PIN de recuperação.
 - `sessions` – registra as sessões associadas a cada usuário.
 - `audio_records` – armazena os áudios processados, vinculados à sessão correspondente.
 

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,8 @@
 CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
-    name TEXT UNIQUE NOT NULL
+    name TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    pin TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS sessions (

--- a/static/script.js
+++ b/static/script.js
@@ -39,7 +39,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 td.append('text', data.original_text);
                 td.append('src_lang', commonData.get('src_lang'));
                 td.append('tgt_lang', commonData.get('tgt_lang'));
-                td.append('user_name', commonData.get('user_name'));
                 td.append('session_name', commonData.get('session_name'));
                 td.append('subject', commonData.get('subject'));
                 td.append('save', commonData.get('save'));

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h1 class="mb-4 text-center">Entrar</h1>
+        {% with messages = get_flashed_messages() %}
+          {% if messages %}
+            <div class="alert alert-danger">{{ messages[0] }}</div>
+          {% endif %}
+        {% endwith %}
+        <form method="post" class="bg-white p-4 rounded shadow-sm">
+            <div class="mb-3">
+                <label for="user_name" class="form-label">Usuário</label>
+                <input type="text" name="user_name" id="user_name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Senha</label>
+                <input type="password" name="password" id="password" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Entrar</button>
+        </form>
+        <div class="text-center mt-3">
+            <a href="{{ url_for('register_view') }}">Criar conta</a> |
+            <a href="{{ url_for('reset_view') }}">Esqueci a senha</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Criar Conta</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h1 class="mb-4 text-center">Criar Conta</h1>
+        {% with messages = get_flashed_messages() %}
+          {% if messages %}
+            <div class="alert alert-info">{{ messages[0] }}</div>
+          {% endif %}
+        {% endwith %}
+        <form method="post" class="bg-white p-4 rounded shadow-sm">
+            <div class="mb-3">
+                <label for="user_name" class="form-label">Usuário</label>
+                <input type="text" name="user_name" id="user_name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Senha</label>
+                <input type="password" name="password" id="password" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="pin" class="form-label">PIN (para redefinição)</label>
+                <input type="text" name="pin" id="pin" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-success w-100">Registrar</button>
+        </form>
+        <div class="text-center mt-3">
+            <a href="{{ url_for('login_view') }}">Voltar ao login</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/reset.html
+++ b/templates/reset.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Redefinir Senha</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h1 class="mb-4 text-center">Redefinir Senha</h1>
+        {% with messages = get_flashed_messages() %}
+          {% if messages %}
+            <div class="alert alert-info">{{ messages[0] }}</div>
+          {% endif %}
+        {% endwith %}
+        <form method="post" class="bg-white p-4 rounded shadow-sm">
+            <div class="mb-3">
+                <label for="user_name" class="form-label">Usuário</label>
+                <input type="text" name="user_name" id="user_name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="pin" class="form-label">PIN</label>
+                <input type="text" name="pin" id="pin" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="new_password" class="form-label">Nova Senha</label>
+                <input type="password" name="new_password" id="new_password" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Atualizar</button>
+        </form>
+        <div class="text-center mt-3">
+            <a href="{{ url_for('login_view') }}">Voltar</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/sessions.html
+++ b/templates/sessions.html
@@ -7,35 +7,25 @@
 </head>
 <body class="bg-light">
     <div class="container py-5">
-        <h1 class="mb-4 text-center">Escolha a Sessão</h1>
-        <form method="post" class="bg-white p-4 rounded shadow-sm mb-4">
-            <div class="mb-3">
-                <label for="user_name" class="form-label">Nome do usuário:</label>
-                <input type="text" name="user_name" id="user_name" class="form-control" value="{{ user_name or '' }}" required>
-            </div>
-            <button type="submit" class="btn btn-primary">Buscar Sessões</button>
-        </form>
-        {% if sessions is not none %}
+        <h1 class="mb-4 text-center">Sessões de {{ user_name }}</h1>
         <div class="bg-white p-4 rounded shadow-sm">
-            <h2 class="mb-3">Sessões de {{ user_name }}</h2>
+            <a href="{{ url_for('logout_view') }}" class="btn btn-sm btn-secondary float-end">Sair</a>
             <ul class="list-group mb-3">
                 {% for s in sessions %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     {{ s.session_name }}
                     <span class="badge bg-secondary">{{ s.record_count }} registros</span>
-                    <a class="btn btn-sm btn-outline-primary" href="{{ url_for('index', user_name=user_name, session_name=s.session_name) }}">Abrir</a>
+                    <a class="btn btn-sm btn-outline-primary" href="{{ url_for('index', session_name=s.session_name) }}">Abrir</a>
                 </li>
                 {% endfor %}
             </ul>
             <form action="{{ url_for('index') }}" method="get" class="mt-3">
-                <input type="hidden" name="user_name" value="{{ user_name }}">
                 <div class="input-group">
                     <input type="text" name="session_name" class="form-control" placeholder="Nova sessão" required>
                     <button class="btn btn-success" type="submit">Criar/Abrir</button>
                 </div>
             </form>
         </div>
-        {% endif %}
-    </div>
+        </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable user accounts with password and PIN for reset
- add login, registration, reset and logout routes
- update templates to support auth workflows
- adjust JS and database functions accordingly
- update docs and schema

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c449ecd94832aa35c862901da89bd