### PR TITLE
Improve session flow and layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -75,39 +75,39 @@
                     </div>
                 {% endfor %}
             {% endif %}
-        </div>
 
-        {% if records %}
-        <div class="mt-5">
-            <div class="d-flex justify-content-between align-items-center mb-3">
-                <h2 class="h4 mb-0">Áudios processados</h2>
-                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#records-collapse">Mostrar/Esconder</button>
+            {% if records %}
+            <div class="mt-5">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h2 class="h4 mb-0">Áudios processados</h2>
+                    <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#records-collapse">Mostrar/Esconder</button>
+                </div>
+                <div class="collapse show" id="records-collapse">
+                    <div class="table-responsive">
+                        <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>Assunto</th>
+                                <th>Áudio</th>
+                                <th>Texto Extraído</th>
+                                <th>Texto Traduzido</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rec in records %}
+                            <tr>
+                                <td>{{ rec.subject }}</td>
+                                <td><a href="{{ rec.audio_path }}" target="_blank">Arquivo</a></td>
+                                <td>{{ rec.original_text }}</td>
+                                <td>{{ rec.translated_text }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </div>
-            <div class="collapse show" id="records-collapse">
-                <div class="table-responsive">
-                    <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>Assunto</th>
-                            <th>Áudio</th>
-                            <th>Texto Extraído</th>
-                            <th>Texto Traduzido</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for rec in records %}
-                        <tr>
-                            <td>{{ rec.subject }}</td>
-                            <td><a href="{{ rec.audio_path }}" target="_blank">Arquivo</a></td>
-                            <td>{{ rec.original_text }}</td>
-                            <td>{{ rec.translated_text }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
+            {% endif %}
         </div>
-        {% endif %}
 
         <div class="alert alert-info mt-4" role="alert">
             Este aplicativo utiliza o modelo <strong>openai/whisper-large-v3-turbo</strong>

--- a/web.py
+++ b/web.py
@@ -36,6 +36,8 @@ LANG_OPTIONS = list(LANG_CODE.keys())
 @app.route('/', methods=['GET', 'POST'])
 def login_view():
     """Login using user name and password."""
+    if session.get('user_name'):
+        return redirect(url_for('sessions_view'))
     if request.method == 'POST':
         user_name = request.form['user_name']
         password = request.form['password']


### PR DESCRIPTION
## Summary
- avoid showing login page when already logged in
- show processed audio table inside the results section

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c48b878dc832aa378d0ce30d3ca99