### PR TITLE
Fix base image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx/unit:1.34.2-python3.11
+FROM nginx/unit:1.29.1-python3.11
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- pin Unit image to a valid tag

## Testing
- `docker build -t audio-app .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c4d1705bc832a9d41c2cebaa3c10a